### PR TITLE
feat(probe): Allow probing a specific address for cameras

### DIFF
--- a/lib/node-onvif.js
+++ b/lib/node-onvif.js
@@ -52,9 +52,9 @@ Onvif.prototype.startDiscovery = function(callback) {
 };
 
 /* ------------------------------------------------------------------
-* Method: startProbe([callback])
+* Method: startProbe([callback, address])
 * ---------------------------------------------------------------- */
-Onvif.prototype.startProbe = function(callback) {
+Onvif.prototype.startProbe = function(callback, address) {
 	let promise = new Promise((resolve, reject) => {
 		this._devices = {};
 		this._udp = mDgram.createSocket('udp4');
@@ -88,7 +88,7 @@ Onvif.prototype.startProbe = function(callback) {
 							types = probe_match['Types'].split(/\s+/);
 						} else if(typeof(probe_match['Types']) === 'object' && typeof(probe_match['Types']['_']) === 'string') {
 							types = probe_match['Types']['_'].split(/\s+/)
-						}							
+						}
 					}
 				} catch(e) {
 					return;
@@ -127,7 +127,7 @@ Onvif.prototype.startProbe = function(callback) {
 
 		this._udp.bind(() => {
 			this._udp.removeAllListeners('error');
-			this._sendProbe().then(() => {
+			this._sendProbe(undefined, address).then(() => {
 				// Do nothing.
 			}).catch((error) => {
 				reject(error);
@@ -167,7 +167,10 @@ Onvif.prototype._execCallback = function(callback, arg1, arg2) {
 	}
 };
 
-Onvif.prototype._sendProbe = function(callback) {
+Onvif.prototype._sendProbe = function(callback, address) {
+	if (!address) {
+		address = this._MULTICAST_ADDRESS;
+	}
 	let soap_tmpl = '';
 	soap_tmpl += '<?xml version="1.0" encoding="UTF-8"?>';
 	soap_tmpl += '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">';
@@ -211,7 +214,7 @@ Onvif.prototype._sendProbe = function(callback) {
 			let soap = soap_list.shift();
 			if(soap) {
 				let buf = Buffer.from(soap, 'utf8');
-				this._udp.send(buf, 0, buf.length, this._PORT, this._MULTICAST_ADDRESS, (error, bytes) => {
+				this._udp.send(buf, 0, buf.length, this._PORT, address, (error, bytes) => {
 					this._discovery_interval_timer = setTimeout(() => {
 						send();
 					}, this._DISCOVERY_INTERVAL);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-onvif",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "The node-onvif is a Node.js module which allows you to communicate with the network camera which supports the ONVIF specifications.",
   "engines": {
     "node" : ">=4.4"


### PR DESCRIPTION
The current implementation of node-onvif sends a multicast packet,
which is sent on only one interface.  For systems with multiple
network interfaces, we need to allow probing on specific interface
addresses.  This change allows the caller to specify an address
in the startProbe method.  If no address is given, the multicast
address is used (so no change to existing functionality).  If an
address is given, the probe packet is sent to that address.

NB: This commit places the 'address' parameter after the 'callback' parameter and updates the version to 0.2.0.