### PR TITLE
fix(onvif): Stop clearing the device list

### DIFF
--- a/lib/node-onvif.js
+++ b/lib/node-onvif.js
@@ -52,11 +52,32 @@ Onvif.prototype.startDiscovery = function(callback) {
 };
 
 /* ------------------------------------------------------------------
-* Method: startProbe([callback, address])
+* Method: resetDeviceList()
 * ---------------------------------------------------------------- */
-Onvif.prototype.startProbe = function(callback, address) {
-	let promise = new Promise((resolve, reject) => {
+Onvif.prototype.resetDeviceList = function() {
 		this._devices = {};
+}
+
+/* ------------------------------------------------------------------
+* Method: startProbe([callback, options])
+* callback: method taking two parameters: err, device_list
+* options: object having the following fields:
+*   resetDeviceList: indicates whether the internal list of devices
+*     should be emptied before probing; defaults to true
+*   address: the address/hostname to which the probe message should
+*     be sent; defaults to the multicast address
+* ---------------------------------------------------------------- */
+Onvif.prototype.startProbe = function(
+	callback,
+	options = {
+		resetDeviceList = true,
+		address = this._MULTICAST_ADDRESS
+	} = {}
+) {
+	let promise = new Promise((resolve, reject) => {
+		if (options.resetDeviceList) {
+			this.resetDeviceList();
+		}
 		this._udp = mDgram.createSocket('udp4');
 
 		this._udp.once('error', (error) => {
@@ -127,7 +148,7 @@ Onvif.prototype.startProbe = function(callback, address) {
 
 		this._udp.bind(() => {
 			this._udp.removeAllListeners('error');
-			this._sendProbe(undefined, address).then(() => {
+			this._sendProbe(undefined, options.address).then(() => {
 				// Do nothing.
 			}).catch((error) => {
 				reject(error);
@@ -147,7 +168,7 @@ Onvif.prototype.startProbe = function(callback, address) {
 	});
 
 	if(this._isValidCallback(callback)) {
-		promise.then((device_list) => {
+		return promise.then((device_list) => {
 			callback(null, device_list);
 		}).catch((error) => {
 			callback(error);
@@ -168,9 +189,6 @@ Onvif.prototype._execCallback = function(callback, arg1, arg2) {
 };
 
 Onvif.prototype._sendProbe = function(callback, address) {
-	if (!address) {
-		address = this._MULTICAST_ADDRESS;
-	}
 	let soap_tmpl = '';
 	soap_tmpl += '<?xml version="1.0" encoding="UTF-8"?>';
 	soap_tmpl += '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lgs-innovations/node-onvif",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The node-onvif is a Node.js module which allows you to communicate with the network camera which supports the ONVIF specifications.",
   "engines": {
     "node" : ">=4.4"


### PR DESCRIPTION
The current implementation assumes the list of devices needs to be
reset on every probe.  Unfortunately, this does not allow for probing
multiple network interfaces.  This change adds a method that allows
the caller to clear the list of devices (resetDeviceList()) and also
uses an object as the second parameter to startProbe.  This "options"
object has two fields: resetDeviceList which is used to direct this
method whether or not to clear the list of devices (default is true),
and address which is used to indicate the IP address/hostname to which
the probe message is to be sent (default is the multicast address).